### PR TITLE
Workaround for the m68k-amigaos c:Info command

### DIFF
--- a/src/fsinfodata.c
+++ b/src/fsinfodata.c
@@ -39,7 +39,11 @@ static void FbxFillInfoData(struct FbxFS *fs, struct InfoData *info) {
 		info->id_NumBlocks = st.f_blocks;
 		info->id_NumBlocksUsed = st.f_blocks - st.f_bfree;
 		info->id_BytesPerBlock = st.f_frsize;
+#ifdef __AROS__
 		info->id_DiskType = fs->dostype;
+#else
+		info->id_DiskType = ID_INTER_FFS_DISK;
+#endif
 		info->id_VolumeNode = MKBADDR(vol);
 
 		if (!IsMinListEmpty(&vol->locklist) ||


### PR DESCRIPTION
Apparently the 3.x Info command doesn't like custom disk types, you'll get an "Unreadable disk" error instead of the details. As a workaround handlers usually pretend to be FFS in id_DiskType.