### PR TITLE
Fix some charset detection problems

### DIFF
--- a/src/codesets.c
+++ b/src/codesets.c
@@ -92,7 +92,7 @@ country2cs[] =
 	{ MAKE_ID('H','R',0,0),   MAKE_ID('H','R','V',0), FBX_CS_ISO_8859_2     },
 	{ MAKE_ID('I',0,0,0),     MAKE_ID('I','T','A',0), FBX_CS_ISO_8859_1_EUR },
 	{ MAKE_ID('L','T',0,0),   MAKE_ID('L','T','U',0), FBX_CS_ISO_8859_13    },
-	{ MAKE_ID('H','U',0,0),   MAKE_ID('H','U','N',0), FBX_CS_ISO_8859_2     },
+	{ MAKE_ID('H',0,0,0),     MAKE_ID('H','U','N',0), FBX_CS_ISO_8859_2     },
 	{ MAKE_ID('N','L',0,0),   MAKE_ID('N','L','D',0), FBX_CS_ISO_8859_1_EUR },
 	{ MAKE_ID('N',0,0,0),     MAKE_ID('N','O','R',0), FBX_CS_ISO_8859_1_EUR },
 	{ MAKE_ID('P','L',0,0),   MAKE_ID('P','O','L',0), FBX_CS_ISO_8859_2     },

--- a/src/init.c
+++ b/src/init.c
@@ -61,7 +61,7 @@ static struct FileSysBoxBase *LibInit (REG(d0, struct FileSysBoxBase *libBase),
 		goto error;
 	}
 
-	libBase->localebase = OpenLibrary((CONST_STRPTR)"locale.library", 39);
+	libBase->localebase = OpenLibrary((CONST_STRPTR)"locale.library", 38);
 
 #ifdef __AROS__
 	libBase->aroscbase = OpenLibrary((CONST_STRPTR)"arosc.library", 41);

--- a/src/main/FbxSetupFS.c
+++ b/src/main/FbxSetupFS.c
@@ -397,7 +397,7 @@ static void FbxGetCharsetMapTable(struct FbxFS *fs) {
 			}
 
 			if (cs != NULL && cs->gen_maptab != NULL) {
-				fs->maptable = (FbxUCS *)AllocMem(MEMF_ANY, 256*sizeof(FbxUCS));
+				fs->maptable = (FbxUCS *)AllocMem(256*sizeof(FbxUCS), MEMF_ANY);
 				if (fs->maptable != NULL)
 					cs->gen_maptab(fs->maptable);
 			}


### PR DESCRIPTION
The main problem was that the arguments for AllocMem were the wrong way around, I also fixed a couple smaller issues, like the compatibility with AmigaOS 3.0. This fixed all the problems I found in issue #3.