### PR TITLE
replace bzero() with memset()

### DIFF
--- a/src/diskchange.c
+++ b/src/diskchange.c
@@ -66,7 +66,7 @@ struct FbxDiskChangeHandler *FbxAddDiskChangeHandler(struct FbxFS *fs, FbxDiskCh
 	interrupt = AllocPooled(fs->mempool, sizeof(*interrupt));
 	if (interrupt == NULL) goto cleanup;
 
-	bzero(interrupt, sizeof(*interrupt));
+	memset(interrupt, 0, sizeof(*interrupt));
 	interrupt->is_Node.ln_Type = NT_INTERRUPT;
 #ifdef __AROS__
 	interrupt->is_Node.ln_Name = (char *)AROS_BSTR_ADDR(fs->devnode->dn_Name);

--- a/src/doslist.c
+++ b/src/doslist.c
@@ -145,7 +145,7 @@ struct Process *StartDosListProc(struct FileSysBoxBase *libBase) {
 		struct Library *SysBase = libBase->sysbase;
 		static struct Message msg;
 
-		bzero(&msg, sizeof(msg));
+		memset(&msg, 0, sizeof(msg));
 		msg.mn_Node.ln_Type = NT_MESSAGE;
 		msg.mn_Node.ln_Name = (char *)libBase;
 		msg.mn_Length = sizeof(msg);

--- a/src/fsexaminenext.c
+++ b/src/fsexaminenext.c
@@ -84,7 +84,7 @@ int FbxReadDir(struct FbxFS *fs, struct FbxLock *lock) {
 			fs->r2 = ERROR_NO_FREE_STORE;
 			return DOSFALSE;
 		}
-		bzero(fi, sizeof(*fi));
+		memset(fi, 0, sizeof(*fi));
 
 		error = Fbx_opendir(fs, lock->entry->path, fi);
 		if (error) {

--- a/src/fsinfodata.c
+++ b/src/fsinfodata.c
@@ -21,14 +21,14 @@
 static void FbxFillInfoData(struct FbxFS *fs, struct InfoData *info) {
 	struct FbxVolume *vol = fs->currvol;
 
-	bzero(info, sizeof(*info));
+	memset(info, 0, sizeof(*info));
 
 	info->id_UnitNumber = fs->fssm ? fs->fssm->fssm_Unit : -1;
 
 	if (OKVOLUME(vol)) {
 		struct statvfs st;
 
-		bzero(&st, sizeof(st));
+		memset(&st, 0, sizeof(st));
 
 		Fbx_statfs(fs, "/", &st);
 

--- a/src/fsopen.c
+++ b/src/fsopen.c
@@ -62,7 +62,7 @@ static int FbxCreateOpenLock(struct FbxFS *fs, struct FileHandle *fh, struct Fbx
 		fs->r2 = ERROR_NO_FREE_STORE;
 		return DOSFALSE;
 	}
-	bzero(lock->info, sizeof(*lock->info));
+	memset(lock->info, 0, sizeof(*lock->info));
 
 	if (fs->currvol->vflags & FBXVF_READ_ONLY)
 		lock->info->flags = O_RDONLY;

--- a/src/fsopenfromlock.c
+++ b/src/fsopenfromlock.c
@@ -48,7 +48,7 @@ int FbxOpenLock(struct FbxFS *fs, struct FileHandle *fh, struct FbxLock *lock) {
 		fs->r2 = ERROR_NO_FREE_STORE;
 		return DOSFALSE;
 	}
-	bzero(lock->info, sizeof(*lock->info));
+	memset(lock->info, 0, sizeof(*lock->info));
 
 	if (fs->currvol->vflags & FBXVF_READ_ONLY)
 		lock->info->flags = O_RDONLY;

--- a/src/lockhandler.c
+++ b/src/lockhandler.c
@@ -212,7 +212,7 @@ static int FbxLockHandlerProc(void) {
 
 					id = (struct InfoData *)BADDR(pkt->dp_Arg2);
 
-					bzero(id, sizeof(*id));
+					memset(id, 0, sizeof(*id));
 
 					id->id_UnitNumber    = -1;
 					id->id_DiskState     = ID_VALIDATING;
@@ -330,7 +330,7 @@ struct Process *StartLockHandlerProc(struct FileSysBoxBase *libBase) {
 		struct Library *SysBase = libBase->sysbase;
 		static struct Message msg;
 
-		bzero(&msg, sizeof(msg));
+		memset(&msg, 0, sizeof(msg));
 		msg.mn_Node.ln_Type = NT_MESSAGE;
 		msg.mn_Node.ln_Name = (char *)libBase;
 		msg.mn_Length = sizeof(msg);

--- a/src/main/FbxCleanupFS.c
+++ b/src/main/FbxCleanupFS.c
@@ -115,7 +115,7 @@ void FbxCleanupFS(
 
 		FbxCleanupTimerIO(fs);
 
-		bzero(fs, sizeof(*fs));
+		memset(fs, 0, sizeof(*fs));
 
 		FreeFbxFS(fs);
 	}

--- a/src/main/FbxEventLoop.c
+++ b/src/main/FbxEventLoop.c
@@ -90,7 +90,7 @@ LONG FbxEventLoop(
 	FbxStartTimer(fs);
 
 #ifndef NODEBUG
-	bzero(&nr, sizeof(nr));
+	memset(&nr, 0, sizeof(nr));
 	nr.nr_Name = (STRPTR)"ENV:FBX_DBGFLAGS";
 	nr.nr_Flags = NRF_SEND_SIGNAL;
 	nr.nr_stuff.nr_Signal.nr_Task = FindTask(NULL);

--- a/src/volume.c
+++ b/src/volume.c
@@ -71,7 +71,7 @@ struct FbxVolume *FbxSetupVolume(struct FbxFS *fs) {
 		return fs->currvol = NULL;
 	}
 
-	bzero(conn, sizeof(*conn));
+	memset(conn, 0, sizeof(*conn));
 
 	initret = Fbx_init(fs, conn);
 	if (initret == (APTR)-2) {


### PR DESCRIPTION
Replace bzero() calls with standard C memset(...,0,...) for portability.
No functional changes intended.
