### PR TITLE
remove strcpy() (use memcpy)

### DIFF
--- a/src/doslist.c
+++ b/src/doslist.c
@@ -217,7 +217,7 @@ static int FbxAsyncDosListCmd(struct FbxFS *fs, struct FbxVolume *vol, int cmd, 
 			msg->fs = fs;
 			msg->vol = vol;
 			msg->cmd = cmd;
-			if (name != NULL) strcpy(msg->name, name);
+			if (name != NULL) memcpy(msg->name, name, strlen(name) + 1);
 			PutMsg(fs->dlproc_port, &msg->msg);
 			res = TRUE;
 		} else {


### PR DESCRIPTION
Replace strcpy() with memcpy() where destination size is known (strlen+1).
No functional changes intended.
