### PR TITLE
lockhandler: fix not-found handling and notify list removal

### DIFF
--- a/src/lockhandler.c
+++ b/src/lockhandler.c
@@ -120,24 +120,28 @@ static int FbxLockHandlerProc(void) {
 					struct Node *node;
 
 					lock = (struct FbxLock *)BADDR(pkt->dp_Arg1);
-					for (node = (struct Node *)locklist.mlh_Head; node->ln_Succ != NULL; node = node->ln_Succ) {
-						if ((struct FbxLock *)node->ln_Name == lock) {
-							Remove(node);
-							FreeMem(node, sizeof(*node));
+					{
+						BOOL found = FALSE;
+						for (node = (struct Node *)locklist.mlh_Head; node->ln_Succ != NULL; node = node->ln_Succ) {
+							if ((struct FbxLock *)node->ln_Name == lock) {
+								Remove(node);
+								FreeMem(node, sizeof(*node));
 
-							if (lock->mempool != NULL) {
-								DeletePool(lock->mempool);
+								if (lock->mempool != NULL) {
+									DeletePool(lock->mempool);
+								}
+								FreeFbxLock(lock);
+
+								found = TRUE;
+								break;
 							}
-							FreeFbxLock(lock);
+						}
 
+						if (!found) {
+							r1 = DOSFALSE;
+							r2 = ERROR_INVALID_LOCK;
 							break;
 						}
-					}
-
-					if (node == NULL) {
-						r1 = DOSFALSE;
-						r2 = ERROR_INVALID_LOCK;
-						break;
 					}
 
 					r1 = DOSTRUE;
@@ -181,24 +185,28 @@ static int FbxLockHandlerProc(void) {
 					nr = (struct NotifyRequest *)pkt->dp_Arg1;
 
 					nn = (struct FbxNotifyNode *)nr->nr_notifynode;
-					for (node = (struct Node *)locklist.mlh_Head; node->ln_Succ != NULL; node = node->ln_Succ) {
-						if ((struct FbxNotifyNode *)node->ln_Name == nn) {
-							Remove(node);
-							FreeMem(node, sizeof(*node));
+					{
+						BOOL found = FALSE;
+						for (node = (struct Node *)notifylist.mlh_Head; node->ln_Succ != NULL; node = node->ln_Succ) {
+							if ((struct FbxNotifyNode *)node->ln_Name == nn) {
+								Remove(node);
+								FreeMem(node, sizeof(*node));
 
-							FreeFbxNotifyNode(nn);
+								FreeFbxNotifyNode(nn);
 
-							nr->nr_MsgCount = 0;
-							nr->nr_notifynode = (IPTR)NULL;
+								nr->nr_MsgCount = 0;
+								nr->nr_notifynode = (IPTR)NULL;
 
+								found = TRUE;
+								break;
+							}
+						}
+
+						if (!found) {
+							r1 = DOSFALSE;
+							r2 = 0;
 							break;
 						}
-					}
-
-					if (node == NULL) {
-						r1 = DOSFALSE;
-						r2 = 0;
-						break;
 					}
 
 					r1 = DOSTRUE;


### PR DESCRIPTION
Fix incorrect not-found detection in ACTION_FREE_LOCK and ACTION_REMOVE_NOTIFY (sentinel list never yields node==NULL).
Also iterate notifylist for ACTION_REMOVE_NOTIFY instead of locklist.
