### PR TITLE
docs: update README with C99 build note

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,7 @@ update timeouts and more, freeing the file system of these jobs. Version 0.730
 of the library was released as open source and was used as a basis for this
 version.
 
-Build notes: see docs/building.md (C99 compiler required; vbcc: -c99).
+Build notes: see docs/building.md.
 
 The included FbxDismount command can be used to cleanly unmount FUSE file
 systems even if there are outstanding locks/notify requests. Any outstanding


### PR DESCRIPTION
Documentation-only: add a short C99 build note to the README (see docs/building.md for details).
No functional changes.
