### PR TITLE
m68k-amigaos: use NDK3.2R4 as default NDK path

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ endif
 
 ifeq ($(HOST),m68k-amigaos)
 	AS = vasmm68k_mot
-	NDK ?= $(HOME)/Development/NDK3.9
+	NDK ?= $(HOME)/Development/NDK3.2R4
 	ASFLAGS = -Fhunk -I$(NDK)/include/include_i
 	DEFINES += -DENABLE_DP64_SUPPORT -DENABLE_STACKSWAP
 	ARCH_000 = -mcpu=68000 -mtune=68000


### PR DESCRIPTION
This changes the default `NDK` path for `HOST=m68k-amigaos` from `NDK3.9` to `NDK3.2R4`.

Rationale:
- `NDK3.9` is no longer a good onboarding/reference baseline for new contributors.
- AmigaOS 3.x is now an explicit target in the project, so using a clearly identifiable and currently available NDK baseline makes the build setup easier to understand.
- This only changes the default path used for the assembler include files. Local setups can still override `NDK` as before.

No functional code changes intended.