### PR TITLE
FbxSetupFS: validate ops table and optional context pointer

### DIFF
--- a/src/main/FbxSetupFS.c
+++ b/src/main/FbxSetupFS.c
@@ -230,6 +230,7 @@ struct FbxFS *FbxSetupFS(
 	if (fs->notifyreplyport == NULL) goto error;
 
 	// make a copy of fuse_operations
+	if (ops == NULL || opssize <= 0) goto error;
 	CopyMem((APTR)ops, &fs->ops, min(opssize, sizeof(fs->ops)));
 
 	// install dummy functions in empty slots of fuse_operations array.
@@ -284,7 +285,8 @@ struct FbxFS *FbxSetupFS(
 			fs->dostype = tag->ti_Data;
 			break;
 		case FBXT_GET_CONTEXT:
-			*(struct fuse_context **)tag->ti_Data = &fs->fcntx;
+			if (tag->ti_Data != 0)
+				*(struct fuse_context **)tag->ti_Data = &fs->context;
 			break;
 		case FBXT_ACTIVE_UPDATE_TIMEOUT:
 			fs->aut = tag->ti_Data;


### PR DESCRIPTION
This hardens `FbxSetupFS()` against invalid caller input.

Changes:
- reject a NULL operations table
- reject a non-positive operations table size
- only write to `FBXT_GET_CONTEXT` when the caller provided a non-NULL destination pointer

This is intended as a small robustness fix only. No functional behavior changes for valid callers.