### PR TITLE
FbxSetupFS: require startup context for disk change detection

### DIFF
--- a/src/main/FbxSetupFS.c
+++ b/src/main/FbxSetupFS.c
@@ -300,6 +300,7 @@ struct FbxFS *FbxSetupFS(
 #endif
 
 	if (fs->fsflags & FBXF_ENABLE_DISK_CHANGE_DETECTION) {
+		if (fs->fssm == NULL || fs->devnode == NULL) goto error;
 		if (FbxAddDiskChangeHandler(fs, FbxDiskChangeHandler) == NULL) goto error;
 	}
 


### PR DESCRIPTION
This hardens `FbxSetupFS()` when `FBXF_ENABLE_DISK_CHANGE_DETECTION` is used.

Disk change detection requires valid startup context data. `FbxAddDiskChangeHandler()` dereferences both `fs->fssm` and `fs->devnode`, so reject the setup early if either is missing.

This is intended as a small robustness fix only. No functional behavior changes for valid callers.