### PR TITLE
FbxSetupFS: require explicit dostype without startup message

### DIFF
--- a/src/main/FbxSetupFS.c
+++ b/src/main/FbxSetupFS.c
@@ -150,6 +150,7 @@ struct FbxFS *FbxSetupFS(
 	struct FbxFS *fs;
 	struct TagItem *tstate;
 	const struct TagItem *tag;
+	BOOL got_dostype = FALSE;
 
 	ADEBUGF("FbxSetupFS(%#p, %#p, %#p, %ld, %#p)\n", msg, tags, ops, opssize, udata);
 
@@ -282,6 +283,7 @@ struct FbxFS *FbxSetupFS(
 			break;
 		case FBXT_DOSTYPE:
 			fs->dostype = tag->ti_Data;
+			got_dostype = TRUE;
 			break;
 		case FBXT_GET_CONTEXT:
 			*(struct fuse_context **)tag->ti_Data = &fs->fcntx;
@@ -294,6 +296,8 @@ struct FbxFS *FbxSetupFS(
 			break;
 		}
 	}
+
+	if (msg == NULL && !got_dostype) goto error;
 
 #ifdef ENABLE_CHARSET_CONVERSION
 	FbxGetCharsetMapTable(fs);


### PR DESCRIPTION
This makes `FbxSetupFS()` enforce an API requirement that is already documented:

- when no startup message is provided (`msg == NULL`),
- `FBXT_DOSTYPE` must be supplied explicitly.

A small boolean flag is used to track whether `FBXT_DOSTYPE` was actually provided in the tag list, and setup now fails early if it was omitted.

This is intended as a small robustness fix only. No functional behavior changes for valid callers.