### PR TITLE
volume: avoid devnode dereference in default init fallback

### DIFF
--- a/src/volume.c
+++ b/src/volume.c
@@ -24,7 +24,11 @@ static APTR Fbx_init(struct FbxFS *fs, struct fuse_conn_info *conn)
 	}
 	else
 	{
-		const char *devname = (const char *)BADDR(fs->devnode->dn_Name) + 1;
+		const char *devname;
+
+		if (fs->devnode == NULL) return NULL;
+
+		devname = (const char *)BADDR(fs->devnode->dn_Name) + 1;
 #ifdef ENABLE_CHARSET_CONVERSION
 		FbxLocalToUTF8(fs, conn->volume_name, devname, CONN_VOLUME_NAME_BYTES);
 #else


### PR DESCRIPTION
This hardens the default `Fbx_init()` fallback when no filesystem-specific
`init` callback is provided.

Previously the fallback unconditionally dereferenced `fs->devnode` to derive
the volume name. If no startup message/device node was available, this could
crash.

Now the fallback returns early when `fs->devnode` is missing, avoiding the
NULL dereference.

This is intended as a small robustness fix only.