### PR TITLE
filesysbox: return NULL for missing device node in FbxGetFSSM

### DIFF
--- a/src/filesysbox.c
+++ b/src/filesysbox.c
@@ -42,6 +42,7 @@
 
 struct FileSysStartupMsg *FbxGetFSSM(struct Library *sysbase, struct DeviceNode *devnode) {
 	struct Library *SysBase = sysbase;
+	if (devnode == NULL) return NULL;
 	if (IS_VALID_BPTR(devnode->dn_Startup)) {
 		struct FileSysStartupMsg *fssm = BADDR(devnode->dn_Startup);
 


### PR DESCRIPTION
This hardens `FbxGetFSSM()` against a missing device node.

Instead of dereferencing `devnode` unconditionally, return `NULL` when no
device node was provided.

This is intended as a small robustness fix only.