### PR TITLE
docs: clarify FBXT_DOSTYPE fallback semantics

### DIFF
--- a/src/main/FbxSetupFS.c
+++ b/src/main/FbxSetupFS.c
@@ -65,7 +65,9 @@
 *
 *       FBXT_DOSTYPE (ULONG)
 *           Overrides the dostype from fssm->fssm_Environ.
-*           Must be given if there is no msg.
+*           If omitted, filesysbox falls back to ID_DOS_DISK.
+*           This tag should be provided when no startup msg is available
+*           and a specific dostype is required.
 *
 *       FBXT_GET_CONTEXT (struct fuse_context **)
 *           Puts the address of filesystem context in the pointer


### PR DESCRIPTION
This updates the `FBXT_DOSTYPE` documentation to match the actual fallback
behavior.

When no startup msg is provided and `FBXT_DOSTYPE` is omitted, filesysbox
falls back to `ID_DOS_DISK` instead of treating this as an error.

The updated wording keeps `FBXT_DOSTYPE` documented as the way to request a
specific dostype, but no longer describes it as mandatory in all no-msg
cases.