### PR TITLE
internal: add non-GCC fallback for STATIC_ASSERT

### DIFF
--- a/src/filesysbox_internal.h
+++ b/src/filesysbox_internal.h
@@ -38,7 +38,9 @@
 #ifdef __GNUC__
 #define STATIC_ASSERT(cond,msg) _Static_assert(cond, msg)
 #else
-#define STATIC_ASSERT(cond,msg)
+#define STATIC_ASSERT_GLUE(a,b) a##b
+#define STATIC_ASSERT_XGLUE(a,b) STATIC_ASSERT_GLUE(a,b)
+#define STATIC_ASSERT(cond,msg) typedef char STATIC_ASSERT_XGLUE(static_assertion_,__LINE__)[(cond) ? 1 : -1]
 #endif
 
 #ifndef ACTION_GET_DISK_FSSM


### PR DESCRIPTION
Keep the existing GCC `_Static_assert` path unchanged, but add a simple
non-GCC fallback for `STATIC_ASSERT` instead of compiling those checks out
entirely.

This preserves compile-time layout/invariant checks in the non-GCC path
without changing the current GCC behavior.