### PR TITLE
Internal portability and compatibility cleanups

### DIFF
--- a/src/init.c
+++ b/src/init.c
@@ -7,6 +7,11 @@
 
 #include <exec/alerts.h>
 #include <exec/resident.h>
+/* Include exec/initializers.h before filesysbox_vectors.c is pulled in below.
+ * This makes OFFSET come from exec/initializers.h first and avoids a later
+ * macro conflict with SDI_compiler.h without needing a local #undef.
+ */
+#include <exec/initializers.h>
 #include "filesysbox_internal.h"
 #include "filesysbox.library_rev.h"
 


### PR DESCRIPTION
This PR contains a small set of internal portability and compatibility cleanups with no intended behavioral changes.

Changes included:

- provide a non-GCC `STATIC_ASSERT` fallback in `filesysbox_internal.h`
- switch internal debug macros to C99 variadic macros
- avoid the local `OFFSET` macro conflict in `init.c` before including `filesysbox_vectors.c`
- remove unused `SysBase` declarations in `allocvecpooled.c` and `fsexamineallend.c`

These are internal code hygiene fixes found during compiler-compatibility review. No functional changes are intended for existing supported build paths.