### PR TITLE
Document __NOLIBBASE__ as a build assumption

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -9,6 +9,14 @@ When building with vbcc, make sure C99 mode is enabled.
 
 ## Compiler notes
 
+### Build assumptions
+
+The project build defines `__NOLIBBASE__` in the project makefiles.
+
+This affects how the Amiga `proto/` headers behave: global library base declarations are disabled, so explicit library base declarations in the source tree are intentional in some places.
+
+Contributors working on portability, compiler-compatibility, or cleanup changes should keep this in mind before treating explicit `extern` library base declarations as redundant.
+
 ### m68k-amigaos
 
 Currently, the only officially supported compiler for building filesysbox on m68k-amigaos is GCC.
@@ -17,4 +25,4 @@ The maintainer recommends bebbo's GCC 6.5.0b (this is what is used for releases)
 ### vbcc
 
 Building with vbcc is not officially supported at this time.
-A dedicated vbcc build setup (ideally a makefile.vbcc) would be needed before it can be recommended.
+A dedicated vbcc build setup (for example a makefile.vbcc) would be needed before it can be recommended.


### PR DESCRIPTION
This PR documents `__NOLIBBASE__` as part of the current build assumptions.

Changes included:

- add a short "Build assumptions" note to `docs/building.md`
- explain that `__NOLIBBASE__` is defined by the project makefiles
- explain the consequence for Amiga `proto/` headers and explicit library base declarations
- slightly reword the vbcc note for readability

This is intended to make the existing build model easier to understand for contributors doing portability, compiler-compatibility, or cleanup work.