### PR TITLE
Document FUSE compatibility for fbx_stat time fields

### DIFF
--- a/include/libraries/filesysbox.h
+++ b/include/libraries/filesysbox.h
@@ -47,6 +47,10 @@ typedef QUAD fbx_off_t;
 #undef st_ctime
 #endif
 
+/* The direct time fields (st_atime/st_mtime/st_ctime and the corresponding
+ * *timensec fields) are kept for compatibility with FUSE file system code
+ * that expects these names to exist.
+ */
 struct fbx_stat {
 	mode_t          st_mode;
 	UQUAD           st_ino;


### PR DESCRIPTION
This PR adds a short note to `include/libraries/filesysbox.h` explaining why `struct fbx_stat` exposes the direct time fields in addition to the explicit `timespec` members.

Changes included:

- document that the direct `st_atime` / `st_mtime` / `st_ctime` and corresponding `*timensec` fields are kept for compatibility with FUSE file system code
- place the note directly next to `struct fbx_stat` for easier API context

This is intended as a small documentation improvement to make the purpose of the current public API layout clearer.