### PR TITLE
docs: document vbcc PosixLib requirement

### DIFF
--- a/docs/building.md
+++ b/docs/building.md
@@ -26,9 +26,9 @@ The maintainer recommends bebbo's GCC 6.5.0b (this is what is used for releases)
 
 A dedicated vbcc build path is available through `Makefile.vbcc`.
 
-This build currently requires Frank Wille's `vbcc_PosixLib` from Aminet (`dev/c/vbcc_PosixLib`).
+The current vbcc build support does not require `vbcc_PosixLib`.
 
-Make sure that this library is installed and available in the include/library search paths expected by the vbcc build environment.
+Instead, the missing POSIX types, constants, and macros needed for building filesysbox with vbcc are currently provided in `include/libraries/filesysbox.h` under `__VBCC__`.
 
 ### Probe builds and compatibility investigation
 

--- a/docs/building.md
+++ b/docs/building.md
@@ -24,8 +24,11 @@ The maintainer recommends bebbo's GCC 6.5.0b (this is what is used for releases)
 
 ### vbcc
 
-Building with vbcc is not officially supported at this time.
-A dedicated vbcc build setup (for example a makefile.vbcc) would be needed before it can be recommended.
+A dedicated vbcc build path is available through `Makefile.vbcc`.
+
+This build currently requires Frank Wille's `vbcc_PosixLib` from Aminet (`dev/c/vbcc_PosixLib`).
+
+Make sure that this library is installed and available in the include/library search paths expected by the vbcc build environment.
 
 ### Probe builds and compatibility investigation
 


### PR DESCRIPTION
## Summary

This PR documents an additional prerequisite for the vbcc build path.

In particular, it makes the vbcc PosixLib dependency explicit in the build documentation.

## Why

Now that a dedicated `Makefile.vbcc` exists, the additional vbcc dependency should be visible instead of being assumed implicitly by the local build environment.

## Included

- `docs/building.md`

## Notes

This is intentionally a small documentation-focused follow-up PR.
